### PR TITLE
Implement first steps to "bring your own controls"

### DIFF
--- a/measures/add_demo_noon_to_six/LICENSE.md
+++ b/measures/add_demo_noon_to_six/LICENSE.md
@@ -1,0 +1,11 @@
+Copyright (c) 2024-present Oak Ridge National Laboratory, managed by UT-Battelle, Alliance for Sustainable Energy, LLC, and contributors. 
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/measures/add_demo_noon_to_six/measure.py
+++ b/measures/add_demo_noon_to_six/measure.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: 2024-present Oak Ridge National Laboratory, managed by UT-Battelle, Alliance for Sustainable Energy, LLC, and contributors
+#
+# SPDX-License-Identifier: BSD-3-Clause
+import typing
+import os
+
+import openstudio
+
+thermaltank_custom_module = '''# This file is generated code, modify at your own risk.
+from enum import Enum
+
+class Mode(Enum):
+    CHARGE = 1
+    IDLE = 0
+    DISCHARGE = -1
+
+MODE_SCHEDULE_TYPE = 'Schedule:Compact'
+MODE_SCHEDULE_NAME = 'Something'
+'''
+
+
+class AddDemoNoonToSix(openstudio.measure.ModelMeasure):
+    """A ModelMeasure."""
+
+    def name(self):
+        """Returns the human readable name.
+
+        Measure name should be the title case of the class name.
+        The measure name is the first contact a user has with the measure;
+        it is also shared throughout the measure workflow, visible in the OpenStudio Application,
+        PAT, Server Management Consoles, and in output reports.
+        As such, measure names should clearly describe the measure's function,
+        while remaining general in nature
+        """
+        return "Add Demo Noon to Six"
+
+    def description(self):
+        """Human readable description.
+
+        The measure description is intended for a general audience and should not assume
+        that the reader is familiar with the design and construction practices suggested by the measure.
+        """
+        return "Add the demo Python plugin that runs a TES system (via a schedule) from noon until 6PM."
+
+    def modeler_description(self):
+        """Human readable description of modeling approach.
+
+        The modeler description is intended for the energy modeler using the measure.
+        It should explain the measure's intent, and include any requirements about
+        how the baseline model must be set up, major assumptions made by the measure,
+        and relevant citations or references to applicable modeling resources
+        """
+        return "Add the demo Python plugin that runs a TES system (via a schedule) from noon until 6PM."
+
+    def arguments(self, model: typing.Optional[openstudio.model.Model] = None):
+        """Prepares user arguments for the measure.
+
+        Measure arguments define which -- if any -- input parameters the user may set before running the measure.
+        """
+        args = openstudio.measure.OSArgumentVector()
+
+        types = ['ThermalTank-Ice', 'ThermalTank-ChilledWater', 'PackagedIceStorage']
+        arg = openstudio.measure.OSArgument.makeChoiceArgument("tes_type", types, True)
+        arg.setDisplayName("TES type")
+        arg.setDescription("The TES system that is to be simulated.")
+        arg.setDefaultValue('ThermalTank-Ice')
+        args.append(arg)
+
+        arg = openstudio.measure.OSArgument.makeStringArgument("output_directory", True)
+        arg.setDisplayName("Python plugin output directory")
+        arg.setDescription("The directory to place the case-specific Python plugin file.")
+        arg.setDefaultValue('.')
+        args.append(arg)
+
+        return args
+
+    def run(
+        self,
+        model: openstudio.model.Model,
+        runner: openstudio.measure.OSRunner,
+        user_arguments: openstudio.measure.OSArgumentMap,
+    ):
+        """Defines what happens when the measure is run."""
+        super().run(model, runner, user_arguments)  # Do **NOT** remove this line
+
+        if not (runner.validateUserArguments(self.arguments(model), user_arguments)):
+            return False
+
+        # assign the user inputs to variables
+        tes_type = runner.getChoiceArgumentValue("tes_type", user_arguments)
+        output_directory = runner.getStringArgumentValue("output_directory", user_arguments)
+
+        # check the args for reasonableness
+        if not os.path.exists(output_directory):
+            runner.registerError(f'Output directory "{output_directory}" does not exist.')
+            return False
+
+        # report initial condition of model
+        runner.registerInitialCondition(f'Applying control schedule for "{tes_type}".')
+
+        # write out the system-specific details
+        if tes_type in ['ThermalTank-Ice', 'ThermalTank-ChilledWater']:
+            txt = thermaltank_custom_module
+        else:
+            pass
+
+        with open('case_details.py', 'w') as fp:
+            fp.write(txt)
+
+        # Add Python plugin stuff here
+
+        # report final condition of model
+        runner.registerFinalCondition(f'Control schedule for "{tes_type}" applied.')
+
+        return True
+
+
+# register the measure to be used by the application
+AddDemoNoonToSix().registerWithApplication()

--- a/measures/add_demo_noon_to_six/measure.py
+++ b/measures/add_demo_noon_to_six/measure.py
@@ -15,7 +15,7 @@ class Mode(Enum):
     DISCHARGE = -1
 
 MODE_SCHEDULE_TYPE = 'Schedule:Compact'
-MODE_SCHEDULE_NAME = 'Something'
+MODE_SCHEDULE_NAME = 'Charge Sch'
 '''
 
 
@@ -66,8 +66,8 @@ class AddDemoNoonToSix(openstudio.measure.ModelMeasure):
         arg.setDefaultValue('ThermalTank-Ice')
         args.append(arg)
 
-        arg = openstudio.measure.OSArgument.makeStringArgument("output_directory", True)
-        arg.setDisplayName("Python plugin output directory")
+        arg = openstudio.measure.OSArgument.makeStringArgument("plugin_directory", True)
+        arg.setDisplayName("Python plugin directory")
         arg.setDescription("The directory to place the case-specific Python plugin file.")
         arg.setDefaultValue('.')
         args.append(arg)
@@ -87,12 +87,12 @@ class AddDemoNoonToSix(openstudio.measure.ModelMeasure):
             return False
 
         # assign the user inputs to variables
-        tes_type = runner.getChoiceArgumentValue("tes_type", user_arguments)
-        output_directory = runner.getStringArgumentValue("output_directory", user_arguments)
+        tes_type = runner.getStringArgumentValue("tes_type", user_arguments)
+        plugin_directory = runner.getStringArgumentValue("plugin_directory", user_arguments)
 
         # check the args for reasonableness
-        if not os.path.exists(output_directory):
-            runner.registerError(f'Output directory "{output_directory}" does not exist.')
+        if not os.path.exists(plugin_directory):
+            runner.registerError(f'Output directory "{plugin_directory}" does not exist.')
             return False
 
         # report initial condition of model
@@ -104,7 +104,7 @@ class AddDemoNoonToSix(openstudio.measure.ModelMeasure):
         else:
             pass
 
-        with open('case_details.py', 'w') as fp:
+        with open(os.path.join(plugin_directory, 'case_details.py'), 'w') as fp:
             fp.write(txt)
 
         # Add Python plugin stuff here

--- a/measures/add_demo_noon_to_six/measure.py
+++ b/measures/add_demo_noon_to_six/measure.py
@@ -1,9 +1,7 @@
 # SPDX-FileCopyrightText: 2024-present Oak Ridge National Laboratory, managed by UT-Battelle, Alliance for Sustainable Energy, LLC, and contributors
 #
 # SPDX-License-Identifier: BSD-3-Clause
-import typing
 import os
-
 import openstudio
 
 thermaltank_custom_module = '''# This file is generated code, modify at your own risk.
@@ -18,9 +16,8 @@ MODE_SCHEDULE_TYPE = 'Schedule:Compact'
 MODE_SCHEDULE_NAME = 'Charge Sch'
 '''
 
-
-class AddDemoNoonToSix(openstudio.measure.ModelMeasure):
-    """A ModelMeasure."""
+class AddDemoNoonToSix(openstudio.measure.EnergyPlusMeasure):
+    """An EnergyPlusMeasure."""
 
     def name(self):
         """Returns the human readable name.
@@ -52,7 +49,7 @@ class AddDemoNoonToSix(openstudio.measure.ModelMeasure):
         """
         return "Add the demo Python plugin that runs a TES system (via a schedule) from noon until 6PM."
 
-    def arguments(self, model: typing.Optional[openstudio.model.Model] = None):
+    def arguments(self, workspace: openstudio.Workspace):
         """Prepares user arguments for the measure.
 
         Measure arguments define which -- if any -- input parameters the user may set before running the measure.
@@ -68,7 +65,7 @@ class AddDemoNoonToSix(openstudio.measure.ModelMeasure):
 
         arg = openstudio.measure.OSArgument.makeStringArgument("plugin_directory", True)
         arg.setDisplayName("Python plugin directory")
-        arg.setDescription("The directory to place the case-specific Python plugin file.")
+        arg.setDescription("A directory that is safe to write files to and is in the Python plugin search path list.")
         arg.setDefaultValue('.')
         args.append(arg)
 
@@ -76,14 +73,14 @@ class AddDemoNoonToSix(openstudio.measure.ModelMeasure):
 
     def run(
         self,
-        model: openstudio.model.Model,
+        workspace: openstudio.Workspace,
         runner: openstudio.measure.OSRunner,
         user_arguments: openstudio.measure.OSArgumentMap,
     ):
         """Defines what happens when the measure is run."""
-        super().run(model, runner, user_arguments)  # Do **NOT** remove this line
+        super().run(workspace, runner, user_arguments)  # Do **NOT** remove this line
 
-        if not (runner.validateUserArguments(self.arguments(model), user_arguments)):
+        if not (runner.validateUserArguments(self.arguments(workspace), user_arguments)):
             return False
 
         # assign the user inputs to variables
@@ -108,6 +105,12 @@ class AddDemoNoonToSix(openstudio.measure.ModelMeasure):
             fp.write(txt)
 
         # Add Python plugin stuff here
+        obj = openstudio.IdfObject.new('PythonPlugin_Instance')
+        obj.setString(0, "Demo Charge Control Program")
+        obj.setString(1, 'No')
+        obj.setString(2, "demo_noon_to_six")
+        obj.setString(3, "NoonToSix")
+        workspace.addObject(obj)
 
         # report final condition of model
         runner.registerFinalCondition(f'Control schedule for "{tes_type}" applied.')

--- a/measures/add_demo_noon_to_six/measure.py
+++ b/measures/add_demo_noon_to_six/measure.py
@@ -105,7 +105,7 @@ class AddDemoNoonToSix(openstudio.measure.EnergyPlusMeasure):
             fp.write(txt)
 
         # Add Python plugin stuff here
-        obj = openstudio.IdfObject.new('PythonPlugin_Instance')
+        obj = openstudio.IdfObject(openstudio.IddObjectType('PythonPlugin_Instance'))
         obj.setString(0, "Demo Charge Control Program")
         obj.setString(1, 'No')
         obj.setString(2, "demo_noon_to_six")

--- a/measures/add_demo_noon_to_six/measure.xml
+++ b/measures/add_demo_noon_to_six/measure.xml
@@ -2,10 +2,10 @@
 <measure>
   <schema_version>3.1</schema_version>
   <name>add_demo_noon_to_six</name>
-  <uid>0829f299-2596-4e80-b857-c0da88057a86</uid>
-  <version_id>73c4abc8-6e38-4c28-8304-e087568db093</version_id>
-  <version_modified>2025-11-07T19:21:32Z</version_modified>
-  <xml_checksum>7C8FCF45</xml_checksum>
+  <uid>1c92ca7f-c919-466f-8708-7000efa786dc</uid>
+  <version_id>6bd6ef89-cb55-4060-9167-d5bfe171cdb7</version_id>
+  <version_modified>2025-11-13T18:17:05Z</version_modified>
+  <xml_checksum>5790C37F</xml_checksum>
   <class_name>AddDemoNoonToSix</class_name>
   <display_name>Add Demo Noon to Six</display_name>
   <description>Add the demo Python plugin that runs a TES system (via a schedule) from noon until 6PM.</description>
@@ -35,9 +35,9 @@
       </choices>
     </argument>
     <argument>
-      <name>output_directory</name>
-      <display_name>Python plugin output directory</display_name>
-      <description>The directory to place the case-specific Python plugin file.</description>
+      <name>plugin_directory</name>
+      <display_name>Python plugin directory</display_name>
+      <description>A directory that is safe to write files to and is in the Python plugin search path list.</description>
       <type>String</type>
       <required>true</required>
       <model_dependent>false</model_dependent>
@@ -52,17 +52,12 @@
   <attributes>
     <attribute>
       <name>Measure Type</name>
-      <value>ModelMeasure</value>
+      <value>EnergyPlusMeasure</value>
       <datatype>string</datatype>
     </attribute>
     <attribute>
       <name>Measure Language</name>
       <value>Python</value>
-      <datatype>string</datatype>
-    </attribute>
-    <attribute>
-      <name>Intended Software Tool</name>
-      <value>Apply Measure Now</value>
       <datatype>string</datatype>
     </attribute>
     <attribute>
@@ -98,19 +93,13 @@
       <filename>measure.py</filename>
       <filetype>py</filetype>
       <usage_type>script</usage_type>
-      <checksum>EDEA7DD3</checksum>
-    </file>
-    <file>
-      <filename>example_model.osm</filename>
-      <filetype>osm</filetype>
-      <usage_type>test</usage_type>
-      <checksum>53D14E69</checksum>
+      <checksum>323AADB4</checksum>
     </file>
     <file>
       <filename>test_add_demo_noon_to_six.py</filename>
       <filetype>py</filetype>
       <usage_type>test</usage_type>
-      <checksum>D629D235</checksum>
+      <checksum>D8CED1F5</checksum>
     </file>
   </files>
 </measure>

--- a/measures/add_demo_noon_to_six/measure.xml
+++ b/measures/add_demo_noon_to_six/measure.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0"?>
+<measure>
+  <schema_version>3.1</schema_version>
+  <name>add_demo_noon_to_six</name>
+  <uid>0829f299-2596-4e80-b857-c0da88057a86</uid>
+  <version_id>73c4abc8-6e38-4c28-8304-e087568db093</version_id>
+  <version_modified>2025-11-07T19:21:32Z</version_modified>
+  <xml_checksum>7C8FCF45</xml_checksum>
+  <class_name>AddDemoNoonToSix</class_name>
+  <display_name>Add Demo Noon to Six</display_name>
+  <description>Add the demo Python plugin that runs a TES system (via a schedule) from noon until 6PM.</description>
+  <modeler_description>Add the demo Python plugin that runs a TES system (via a schedule) from noon until 6PM.</modeler_description>
+  <arguments>
+    <argument>
+      <name>tes_type</name>
+      <display_name>TES type</display_name>
+      <description>The TES system that is to be simulated.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>ThermalTank-Ice</default_value>
+      <choices>
+        <choice>
+          <value>ThermalTank-Ice</value>
+          <display_name>ThermalTank-Ice</display_name>
+        </choice>
+        <choice>
+          <value>ThermalTank-ChilledWater</value>
+          <display_name>ThermalTank-ChilledWater</display_name>
+        </choice>
+        <choice>
+          <value>PackagedIceStorage</value>
+          <display_name>PackagedIceStorage</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>output_directory</name>
+      <display_name>Python plugin output directory</display_name>
+      <description>The directory to place the case-specific Python plugin file.</description>
+      <type>String</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>.</default_value>
+    </argument>
+  </arguments>
+  <outputs />
+  <provenances />
+  <tags>
+    <tag>HVAC.HVAC Controls</tag>
+  </tags>
+  <attributes>
+    <attribute>
+      <name>Measure Type</name>
+      <value>ModelMeasure</value>
+      <datatype>string</datatype>
+    </attribute>
+    <attribute>
+      <name>Measure Language</name>
+      <value>Python</value>
+      <datatype>string</datatype>
+    </attribute>
+    <attribute>
+      <name>Intended Software Tool</name>
+      <value>Apply Measure Now</value>
+      <datatype>string</datatype>
+    </attribute>
+    <attribute>
+      <name>Intended Software Tool</name>
+      <value>OpenStudio Application</value>
+      <datatype>string</datatype>
+    </attribute>
+    <attribute>
+      <name>Intended Software Tool</name>
+      <value>Parametric Analysis Tool</value>
+      <datatype>string</datatype>
+    </attribute>
+  </attributes>
+  <files>
+    <file>
+      <filename>LICENSE.md</filename>
+      <filetype>md</filetype>
+      <usage_type>license</usage_type>
+      <checksum>CD7F5672</checksum>
+    </file>
+    <file>
+      <filename>.gitkeep</filename>
+      <filetype>gitkeep</filetype>
+      <usage_type>doc</usage_type>
+      <checksum>00000000</checksum>
+    </file>
+    <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>3.7.0</identifier>
+        <min_compatible>3.7.0</min_compatible>
+      </version>
+      <filename>measure.py</filename>
+      <filetype>py</filetype>
+      <usage_type>script</usage_type>
+      <checksum>EDEA7DD3</checksum>
+    </file>
+    <file>
+      <filename>example_model.osm</filename>
+      <filetype>osm</filetype>
+      <usage_type>test</usage_type>
+      <checksum>53D14E69</checksum>
+    </file>
+    <file>
+      <filename>test_add_demo_noon_to_six.py</filename>
+      <filetype>py</filetype>
+      <usage_type>test</usage_type>
+      <checksum>D629D235</checksum>
+    </file>
+  </files>
+</measure>

--- a/measures/add_path_to_plugin_paths/LICENSE.md
+++ b/measures/add_path_to_plugin_paths/LICENSE.md
@@ -1,0 +1,11 @@
+Copyright (c) 2024-present Oak Ridge National Laboratory, managed by UT-Battelle, Alliance for Sustainable Energy, LLC, and contributors. 
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/measures/add_path_to_plugin_paths/measure.py
+++ b/measures/add_path_to_plugin_paths/measure.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: 2024-present Oak Ridge National Laboratory, managed by UT-Battelle, Alliance for Sustainable Energy, LLC, and contributors
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import openstudio
+
+
+class AddPathToPluginPaths(openstudio.measure.EnergyPlusMeasure):
+    """An EnergyPlusMeasure."""
+
+    def name(self):
+        """Returns the human readable name.
+
+        Measure name should be the title case of the class name.
+        The measure name is the first contact a user has with the measure;
+        it is also shared throughout the measure workflow, visible in the OpenStudio Application,
+        PAT, Server Management Consoles, and in output reports.
+        As such, measure names should clearly describe the measure's function,
+        while remaining general in nature
+        """
+        return "Add Path To Plugin Paths"
+
+    def description(self):
+        """Human readable description.
+
+        The measure description is intended for a general audience and should not assume
+        that the reader is familiar with the design and construction practices suggested by the measure.
+        """
+        return "Add the specified path to the PythonPlugin:SearchPaths object."
+
+    def modeler_description(self):
+        """Human readable description of modeling approach.
+
+        The modeler description is intended for the energy modeler using the measure.
+        It should explain the measure's intent, and include any requirements about
+        how the baseline model must be set up, major assumptions made by the measure,
+        and relevant citations or references to applicable modeling resources
+        """
+        return "Add the specified path to the PythonPlugin:SearchPaths object."
+
+    def arguments(self, workspace: openstudio.Workspace):
+        """Prepares user arguments for the measure.
+
+        Measure arguments define which -- if any -- input parameters the user may set before running the measure.
+        """
+        args = openstudio.measure.OSArgumentVector()
+
+        arg = openstudio.measure.OSArgument.makeStringArgument("path", True)
+        arg.setDisplayName("Path")
+        arg.setDescription("Path to add to the Python search path.")
+        args.append(arg)
+
+        return args
+
+    def run(
+        self,
+        workspace: openstudio.Workspace,
+        runner: openstudio.measure.OSRunner,
+        user_arguments: openstudio.measure.OSArgumentMap,
+    ):
+        """Defines what happens when the measure is run."""
+        super().run(workspace, runner, user_arguments)  # Do **NOT** remove this line
+
+        if not (runner.validateUserArguments(self.arguments(workspace), user_arguments)):
+            return False
+
+        # assign the user inputs to variables
+        path_name = runner.getStringArgumentValue("path", user_arguments)
+
+        # check the zone_name for reasonableness
+        if not path_name:
+            runner.registerError("Empty path was entered.")
+            return False
+
+        # get all thermal zones in the starting workspace
+        objs = workspace.getObjectsByType("PythonPlugin_SearchPaths")
+        if objs:
+            runner.registerInitialCondition(f"The model started with a PythonPlugin:SearchPaths object.")
+            i = objs[0].numFields()
+            objs[0].setString(i+1, path_name)
+        else:
+            runner.registerInitialCondition("The model started without a PythonPlugin:SearchPaths object.")
+            new_object_string = f'''
+PythonPlugin:SearchPaths,
+    PyPaths,     !- Name
+    Yes,         !- Add Current Working Directory to Search Path
+    Yes,         !- Add Input File Directory to Search Path
+    No,          !- Add epin Environment Variable to Search Path
+    {path_name}; !- Search Path 1
+'''
+            idfObject_: openstudio.OptionalIdfObject = openstudio.IdfObject.load(new_object_string)
+            idfObject: openstudio.IdfObject = idfObject_.get()
+            #wsObject: openstudio.OptionalWorkspaceObject = workspace.addObject(idfObject)
+            workspace.addObject(idfObject)
+
+        runner.registerInfo(f"Added path '{path_name}' to PythonPlugin:SearchPaths.")
+
+        # report final condition of model
+        runner.registerFinalCondition("The model finished with a PythonPluginSearchPaths object.")
+
+        return True
+
+
+# register the measure to be used by the application
+AddPathToPluginPaths().registerWithApplication()

--- a/measures/add_path_to_plugin_paths/measure.py
+++ b/measures/add_path_to_plugin_paths/measure.py
@@ -77,7 +77,7 @@ class AddPathToPluginPaths(openstudio.measure.EnergyPlusMeasure):
         if objs:
             runner.registerInitialCondition(f"The model started with a PythonPlugin:SearchPaths object.")
             i = objs[0].numFields()
-            objs[0].setString(i+1, path_name)
+            objs[0].setString(i, path_name)
         else:
             runner.registerInitialCondition("The model started without a PythonPlugin:SearchPaths object.")
             new_object_string = f'''

--- a/measures/add_path_to_plugin_paths/measure.xml
+++ b/measures/add_path_to_plugin_paths/measure.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0"?>
+<measure>
+  <schema_version>3.1</schema_version>
+  <name>add_path_to_plugin_paths</name>
+  <uid>0b169078-e040-42ee-bb56-aae8c8bc3c2d</uid>
+  <version_id>4065d39d-b571-429e-9879-499896b0f97c</version_id>
+  <version_modified>2025-11-13T17:27:55Z</version_modified>
+  <xml_checksum>719CC56B</xml_checksum>
+  <class_name>AddPathToPluginPaths</class_name>
+  <display_name>Add Path To Plugin Paths</display_name>
+  <description>Add the specified path to the PythonPlugin:SearchPaths object.</description>
+  <modeler_description>Add the specified path to the PythonPlugin:SearchPaths object.</modeler_description>
+  <arguments>
+    <argument>
+      <name>path</name>
+      <display_name>Path</display_name>
+      <description>Path to add to the Python search path.</description>
+      <type>String</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+  </arguments>
+  <outputs />
+  <provenances />
+  <tags>
+    <tag>Reporting.QAQC</tag>
+  </tags>
+  <attributes>
+    <attribute>
+      <name>Measure Type</name>
+      <value>EnergyPlusMeasure</value>
+      <datatype>string</datatype>
+    </attribute>
+    <attribute>
+      <name>Measure Language</name>
+      <value>Python</value>
+      <datatype>string</datatype>
+    </attribute>
+    <attribute>
+      <name>Intended Software Tool</name>
+      <value>OpenStudio Application</value>
+      <datatype>string</datatype>
+    </attribute>
+    <attribute>
+      <name>Intended Software Tool</name>
+      <value>Parametric Analysis Tool</value>
+      <datatype>string</datatype>
+    </attribute>
+  </attributes>
+  <files>
+    <file>
+      <filename>LICENSE.md</filename>
+      <filetype>md</filetype>
+      <usage_type>license</usage_type>
+      <checksum>CD7F5672</checksum>
+    </file>
+    <file>
+      <filename>.gitkeep</filename>
+      <filetype>gitkeep</filetype>
+      <usage_type>doc</usage_type>
+      <checksum>00000000</checksum>
+    </file>
+    <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>3.7.0</identifier>
+        <min_compatible>3.7.0</min_compatible>
+      </version>
+      <filename>measure.py</filename>
+      <filetype>py</filetype>
+      <usage_type>script</usage_type>
+      <checksum>21A9382C</checksum>
+    </file>
+    <file>
+      <filename>test_add_path_to_plugin_paths.py</filename>
+      <filetype>py</filetype>
+      <usage_type>test</usage_type>
+      <checksum>DA22A772</checksum>
+    </file>
+  </files>
+</measure>

--- a/resources/demo_noon_to_six.py
+++ b/resources/demo_noon_to_six.py
@@ -21,9 +21,9 @@ class NoonToSix(EnergyPlusPlugin):
 
         hour = self.api.exchange.hour(state)
         if hour < 12:
-            self.actuate(state, Mode.CHARGE)
+            self.actuate(state, Mode.CHARGE.value)
         elif 12 <= hour < 18:
-            self.actuate(state, Mode.DISCHARGE)
+            self.actuate(state, Mode.DISCHARGE.value)
         else:
-            self.actuate(state, Mode.CHARGE)
+            self.actuate(state, Mode.CHARGE.value)
         return 0

--- a/resources/demo_noon_to_six.py
+++ b/resources/demo_noon_to_six.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2024-present Oak Ridge National Laboratory, managed by UT-Battelle, Alliance for Sustainable Energy, LLC, and contributors
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from pyenergyplus.plugin import EnergyPlusPlugin
+from case_details import MODE_SCHEDULE_TYPE, MODE_SCHEDULE_NAME, Mode
+
+class NoonToSix(EnergyPlusPlugin):
+
+    def actuate(self, state, x):
+        self.api.exchange.set_actuator_value(state, self.data['mode_schedule'], x)
+
+    def on_begin_timestep_before_predictor(self, state) -> int:
+        if 'mode_schedule' not in self.data:
+            self.data['mode_schedule'] = self.api.exchange.get_actuator_handle(
+                state, MODE_SCHEDULE_TYPE, "Schedule Value", MODE_SCHEDULE_NAME
+            )
+            if self.data['mode_schedule'] == -1:
+                self.api.runtime.issue_severe(state, "Could not get handle to TES mode schedule")
+                return 1
+
+        hour = self.api.exchange.hour(state)
+        if hour < 12:
+            self.actuate(state, Mode.CHARGE)
+        elif 12 <= hour < 18:
+            self.actuate(state, Mode.DISCHARGE)
+        else:
+            self.actuate(state, Mode.CHARGE)
+        return 0

--- a/src/stor4build/cli/__init__.py
+++ b/src/stor4build/cli/__init__.py
@@ -124,6 +124,7 @@ def run_icetank(osm, epw, openstudio, run_dir, measures_dir, output, measures_on
             # Found it!
             post.append(stor4build.Step(measure_name.replace('_', ' ').title(), measure_name, {'tes_type': tes_type, 
                                                                                                'plugin_directory': os.path.join(run_dir, 'icetank')}))
+            post.append(stor4build.Step('Add Path To Plugin Paths', 'add_path_to_plugin_paths', {'path': os.path.join(run_dir, 'icetank')}))
         else:
             warnings.warn(f'Failed to find measure "{measure_name}", default control will be used.')
         

--- a/src/stor4build/cli/__init__.py
+++ b/src/stor4build/cli/__init__.py
@@ -4,6 +4,7 @@
 import click
 import os
 import stor4build
+import warnings
 
 from ..__about__ import __version__
 
@@ -63,13 +64,15 @@ def run(osm, epw, openstudio, measures_dir, measures_only, run_dir):
 @click.option('--trim-temp', metavar='T', type=click.FloatRange(min=0.0, max=20.0), show_default=True,
               default=stor4build.IceTank.default_trim_temp, help='Trim temperature.')
 @click.option('-b', '--run-baseline', is_flag=True, show_default=True, default=False, help='Run the baseline.')
-@click.option('-c', '--cooling_season_only', is_flag=True, show_default=True, default=False, help='Run only in cooling season.')
+@click.option('-c', '--cooling-season-only', is_flag=True, show_default=True, default=False, help='Run only in cooling season.')
 @click.option('--chw', is_flag=True, show_default=True, default=False, help='Use chilled water as the storage medium.')
 @click.option('--size-fraction', metavar='F', type=click.Choice(['1', '0.9', '0.8', '0.7', '0.6', '0.5']), show_default=True,
               default='1', help='Fraction to use to downsize the chiller.')
+@click.option('--control', metavar='NAME', show_default=True,
+              default='default', help='Specify a built-in control scheme (default | demo12to6) or a measure that implements the scheme.')
 def run_icetank(osm, epw, openstudio, run_dir, measures_dir, output, measures_only,
                 charge_start, charge_end, discharge_start, discharge_end, charge_temp, ntanks, trim_temp, run_baseline,
-                cooling_season_only, chw, size_fraction):
+                cooling_season_only, chw, size_fraction, control):
     """
     Add an ice tank TES system to an OpenStudio model and run it.
     """
@@ -91,7 +94,10 @@ def run_icetank(osm, epw, openstudio, run_dir, measures_dir, output, measures_on
         "size_fraction": float(size_fraction)
     }
     
+    tes_type = 'ThermalTank-Ice'
+    
     if chw:
+        tes_type = 'ThermalTank-ChilledWater'
         arguments['store_ice'] = False
         if charge_temp is None:
             arguments['charge_temp'] = stor4build.IceTank.default_chw_charge_temp
@@ -106,6 +112,21 @@ def run_icetank(osm, epw, openstudio, run_dir, measures_dir, output, measures_on
     post = [stor4build.Step('Add ThermalTank Outputs', 'add_thermaltank_outputs', {'baseline': False})]
     if cooling_season_only:
         post.append(stor4build.Step('Run Cooling Season Only', 'run_cooling_season_only'))
+    if control == 'default':
+        pass
+    else:
+        measure_name = control
+        if control == 'demo12to6':
+            measure_name = 'add_demo_noon_to_six'
+        # For this to work, the measure will need to be in the measures directory
+        control_measure_path = os.path.join(measures_dir, measure_name, 'measure')
+        if os.path.exists(control_measure_path + '.py') or os.path.exists(control_measure_path + '.rb'):
+            # Found it!
+            post.append(stor4build.Step(measure_name.replace('_', ' ').title(), measure_name, {'tes_type': tes_type, 
+                                                                                               'plugin_directory': os.path.join(run_dir, 'icetank')}))
+        else:
+            warnings.warn(f'Failed to find measure "{measure_name}", default control will be used.')
+        
     icetank = stor4build.IceTank('icetank', post_steps=post, **arguments)
     osw = icetank.osw(osm, measures_dir, epw)
     stor4build.run_workflow(openstudio, os.path.join(run_path, icetank.tag()), osw, measures_only=measures_only)
@@ -154,7 +175,7 @@ def run_icetank(osm, epw, openstudio, run_dir, measures_dir, output, measures_on
               show_default=True, default=stor4build.IceTank.default_peak_reduction,
               help='Target percentage to reduce the peak load.')
 @click.option('-s', '--show-sizing', is_flag=True, show_default=True, default=False, help='Show sizing results.')
-@click.option('-c', '--cooling_season_only', is_flag=True, show_default=True, default=False, help='Run only in cooling season.')
+@click.option('-c', '--cooling-season-only', is_flag=True, show_default=True, default=False, help='Run only in cooling season.')
 @click.option('--chw', is_flag=True, show_default=True, default=False, help='Use chilled water as the storage medium.')
 @click.option('--size-fraction', metavar='F', type=click.Choice(['1', '0.9', '0.8', '0.7', '0.6', '0.5']), show_default=True,
               default='1', help='Fraction to use to downsize the chiller.')


### PR DESCRIPTION
This PR implements the first couple of steps towards allowing for users to "bring your own controls" (BYOC). It adds a demo plugin and measure that operate on the mode schedule of the TES system. For now, it only works on the ThermalTank plugin, the packaged system will get tackled later when it is fully integrated. The plugin and measure are not exposed to the API so usage via that route should see no impact.

A walkthrough of the changes is provided, but a high-level summary of the changes is as follows. A plugin and measure have been added:

 - The plugin operates the mode schedule to discharge the TES from noon until 6PM. The plugin needs some model information so that it can find the schedule and operate it:
   -  the name of the schedule,
   -  the schedule type, and
   -  the meaning of values in the mode schedule.
 - The measure sets up the plugin and provides the information that is needed. Presently, the measure takes two arguments:
   - the TES type and
   - the path to a directory in the Python plugin search path that it can safely write files into.

More complex implementations may need additional measure arguments (possibly building type or other parameters) but for now this will do.

The plugin and measure are available through the `run-icetank` subcommand of the command line interface.

Resolves #1, resolves #2